### PR TITLE
Fixed deleteChanged typo

### DIFF
--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -115,7 +115,7 @@ function WebpackServiceWorker(params) {
     });
   }
 
-  function deleteCahnged() {
+  function deleteChanged() {
     var cache = undefined;
 
     return caches.open(CACHE_NAME).then(function (_cache) {

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -114,7 +114,7 @@ function WebpackServiceWorker(params) {
     });
   }
 
-  function deleteCahnged() {
+  function deleteChanged() {
     let cache;
 
     return caches.open(CACHE_NAME).then((_cache) => {


### PR DESCRIPTION
This was causing a console error when using the `changed` caching method.