### PR TITLE
Adds setting to specify extra entries in CACHE section of AppCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Incorrect value: `https://example.com/project`
 #### `updateStrategy: 'changed' | 'all'`
 Cache update strategy. [More details about `updateStrategy`](docs/update-strategies.md)  
 > Default: `'changed'`.
-    
+
 #### `externals: Array<string>`.
 Explicitly marks cache asset as an _external_ asset. If cache asset is not one of _webpack's generated assets_ and is not marked explicitly as _external_, you will recive warning about it into console.
 
@@ -108,6 +108,26 @@ Settings for the `AppCache` cache. Use `null` or `false` to disable `AppCache` g
 
 * `NETWORK`: `string`. Reflects `AppCache`'s `NETWORK` section.  
 _Default:_ `'*'`.
+* `FALLBACK`: `object`. Reflects `AppCache`'s `FALLBACK` section.  
+_Default:_ `null`.
+
+ Example:
+ ```js
+ FALLBACK: {
+   '/some/path': '/some/alternative/path',
+   '/another/path': '/another/alternative/path',
+ }
+ ```
+* `CACHE`: `array`. Reflects additional entries to `AppCache`'s `CACHE` section besides assets built by webpack.
+_Default:_ `null`.
+
+ Example:
+ ```js
+ CACHE: [
+   '/url/to/page/to/cache',
+   '/another-url',
+ ]
+ ```
 * `directory`: `string`. Relative (from the _webpack_'s config `output.path`) output directly path for the `AppCache` emmited files.  
 _Default:_ `'appcache/'`.
 

--- a/lib/app-cache.js
+++ b/lib/app-cache.js
@@ -28,6 +28,7 @@ var AppCache = (function () {
 
     this.NETWORK = options.NETWORK;
     this.FALLBACK = options.FALLBACK;
+    this.CACHE = options.CACHE;
     this.name = 'manifest';
     this.caches = options.caches;
     this.events = !!options.events;
@@ -67,6 +68,10 @@ var AppCache = (function () {
       } : function (a) {
         return a;
       });
+
+      if (this.CACHE) {
+        cache = cache.concat(this.CACHE);
+      }
 
       var path = this.directory + this.name;
       var manifest = this.getManifestTemplate(cache, plugin);

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ var defaultOptions = {
   AppCache: {
     NETWORK: '*',
     FALLBACK: null,
+    CACHE: null,
     directory: 'appcache/',
     caches: ['main'],
     events: false


### PR DESCRIPTION
My use case for this PR is as follows:

I need to specify a set of URLs that is also cached by AppCache, in addition to the assets build by webpack.