### PR TITLE
Document AppCache's FALLBACK option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ _Default:_ `'*'`.
 _Default:_ `'appcache/'`.
 * `events`: `boolean`. Enables runtime events for AppCache. For supported events see `Runtime`'s `install()` options.
 _Default:_ `false`.
+* `FALLBACK`: `object`. Reflects `AppCache`'s `FALLBACK` section. Useful for single page applications making use of HTML5 routing. Example: `{ '/blog': '/' }` will map all navigation requests starting with `/blog` to the domain root when no internet connection is available.
 
 ## Runtime
 


### PR DESCRIPTION
Option was introduced in [1.3](https://github.com/NekR/offline-plugin/blob/master/CHANGELOG.md#13).