### PR TITLE
Pass 'navigateFallbackURL' through to ServiceWorker object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,10 @@ export default class OfflinePlugin {
       };
     }
 
+    if (this.options.navigateFallbackURL && this.options.ServiceWorker) {
+      this.options.ServiceWorker.navigateFallbackURL = this.options.navigateFallbackURL;
+    }
+
     this.REST_KEY = ':rest:';
     this.entryPrefix = '__offline_';
     this.tools = {};


### PR DESCRIPTION
#81 'navigateFallbackURL' config option does not get passed to ServiceWorker config