### PR TITLE
this is for 403 request popup message

### DIFF
--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -331,6 +331,10 @@ function WebpackServiceWorker(params) {
 
     hashesMap = Object.keys(hashesMap).reduce(function (result, hash) {
       var url = new URL(hashesMap[hash], location);
+      // this is for 403 request popup message
+      // when there is one and a new version added
+      // the browser begin an infinity loop
+      request = new Request(request, { credentials: 'same-origin' });
       url.search = '';
 
       result[hash] = url.toString();

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -346,6 +346,10 @@ function WebpackServiceWorker(params) {
 
     hashesMap = Object.keys(hashesMap).reduce((result, hash) => {
       const url = new URL(hashesMap[hash], location);
+      // this is for 403 request popup message
+      // when there is one and a new version added
+      // the browser begin an infinity loop
+      request = new Request(request, {credentials: 'same-origin'});
       url.search = '';
 
       result[hash] = url.toString();


### PR DESCRIPTION
when there is one and a new version the browser begin an infinity loop

this solution fix it by adding a header request that append the credentials.
this why when the service worker detect new content the credentials remain