### PR TITLE
Always specify loaders, even if empty. Fixes #135.

### DIFF
--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -170,8 +170,6 @@ var ServiceWorker = (function () {
         pluginVersion = plugin.pluginVersion;
       }
 
-      var loaders = Object.keys(plugin.loaders).length ? plugin.loaders : void 0;
-
       return ('\n      var ' + this.SW_DATA_VAR + ' = ' + JSON.stringify({
         assets: {
           main: cache('main'),
@@ -192,7 +190,7 @@ var ServiceWorker = (function () {
         relativePaths: plugin.relativePaths,
 
         prefetchRequest: this.prefetchRequest,
-        loaders: loaders,
+        loaders: plugin.loaders,
 
         // These aren't added
         alwaysRevalidate: plugin.alwaysRevalidate,


### PR DESCRIPTION
This is untested but should do the trick.