### PR TITLE
Fix error on add plugin without options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ export default class OfflinePlugin {
       };
     }
 
-    this.cacheMaps = this.stringifyCacheMaps(options.cacheMaps);
+    this.cacheMaps = this.stringifyCacheMaps(this.options.cacheMaps);
 
     this.REST_KEY = ':rest:';
     this.EXTERNALS_KEY = ':externals:';


### PR DESCRIPTION
Fix error when plugin in is added without options
```js
new OfflinePlugin();
```

expected:
```
// no errors
```

actual:
```
Error: Cannot read property 'cacheMaps' of undefined
```