### PR TITLE
Add 'no-cors' issue to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -6,7 +6,6 @@ Yes, it's possible with `pattern matching`, which is performed by [minimatch](ht
 Example: ``main: ['index.html', 'scripts/main.*.js']``.
 
 **Is there a way to prevent/disable console logging?**  
-
 Yes, you can disable/prevent console logging when `webpack.optimize.UglifyPlugin` is used with `compress.drop_console` option. Example:
 
 ```js
@@ -17,3 +16,7 @@ new webpack.optimize.UglifyPlugin({
 })
 ```
 `offline-plugin` automatically detects usage of `UglifyPlugin` and applies it to its generated code.
+
+**Why does the use of `{ mode: 'no-cors' }` return an error when used?**
+This is because the [opaque request](http://stackoverflow.com/questions/36292537/what-is-an-opaque-request-and-what-it-serves-for) made doesn't give us access to the returned response code. We are therefore unable to determine the asset is valid. In this situation we avoid caching potential erroneous requests. Please ensure anything to be cached responds with valid CORS headers. 
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -17,6 +17,6 @@ new webpack.optimize.UglifyPlugin({
 ```
 `offline-plugin` automatically detects usage of `UglifyPlugin` and applies it to its generated code.
 
-**Why does the use of `{ mode: 'no-cors' }` return an error when used?**
+**Why does the use of `{ mode: 'no-cors' }` return an error when used?**  
 This is because the [opaque request](http://stackoverflow.com/questions/36292537/what-is-an-opaque-request-and-what-it-serves-for) made doesn't give us access to the returned response code. We are therefore unable to determine the asset is valid. In this situation we avoid caching potential erroneous requests. Please ensure anything to be cached responds with valid CORS headers. 
 


### PR DESCRIPTION
Updates the FAQ with details around the use of `{ mode: 'no-cors' } when making use of the `prefetchRequest` option.