### PR TITLE
Move runtime usage detection into compilation 'emit' event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,9 +132,7 @@ var OfflinePlugin = (function () {
     this.errors = [];
 
     this.__tests = this.options.__tests;
-    this.flags = {
-      runtimeAdded: false
-    };
+    this.flags = {};
 
     if (this.__tests.pluginVersion) {
       this.pluginVersion = this.__tests.pluginVersion;
@@ -256,7 +254,6 @@ var OfflinePlugin = (function () {
 
           result.loaders.push(_path3['default'].join(__dirname, 'misc/runtime-loader.js') + '?' + JSON.stringify(data));
 
-          _this2.flags.runtimeAdded = true;
           callback(null, result);
         });
       });
@@ -280,7 +277,9 @@ var OfflinePlugin = (function () {
       });
 
       compiler.plugin('emit', function (compilation, callback) {
-        if (!_this2.flags.runtimeAdded && !_this2.__tests.ignoreRuntime) {
+        var runtimeTemplatePath = _path3['default'].resolve(__dirname, '../tpls/runtime-template.js');
+
+        if (compilation.fileDependencies.indexOf(runtimeTemplatePath) === -1 && !_this2.__tests.ignoreRuntime) {
           compilation.errors.push(new Error('OfflinePlugin: Plugin\'s runtime wasn\'t added to one of your bundle entries. See this https://goo.gl/YwewYp for details.'));
           callback();
           return;

--- a/src/index.js
+++ b/src/index.js
@@ -91,9 +91,7 @@ export default class OfflinePlugin {
     this.errors = [];
 
     this.__tests = this.options.__tests;
-    this.flags = {
-      runtimeAdded: false
-    };
+    this.flags = {};
 
     if (this.__tests.pluginVersion) {
       this.pluginVersion = this.__tests.pluginVersion;
@@ -248,7 +246,6 @@ export default class OfflinePlugin {
             '?' + JSON.stringify(data)
         );
 
-        this.flags.runtimeAdded = true;
         callback(null, result);
       });
     });
@@ -272,14 +269,18 @@ export default class OfflinePlugin {
     });
 
     compiler.plugin('emit', (compilation, callback) => {
-      if (!this.flags.runtimeAdded && !this.__tests.ignoreRuntime) {
+      const runtimeTemplatePath = path.resolve(__dirname, '../tpls/runtime-template.js')
+
+      if (
+        compilation.fileDependencies.indexOf(runtimeTemplatePath) === -1 &&
+        !this.__tests.ignoreRuntime
+      ) {
         compilation.errors.push(
           new Error(`OfflinePlugin: Plugin's runtime wasn't added to one of your bundle entries. See this https://goo.gl/YwewYp for details.`)
         );
         callback();
         return;
       }
-
 
       const stats = compilation.getStats().toJson();
 


### PR DESCRIPTION
... and use compilation.fileDependencies to look for runtime-template.js file usage
Fixes #148