### PR TITLE
Fix runtime template using es5 function style

### DIFF
--- a/tests/legacy/fixtures/basic-with-custom-time-update-service/__expected/main.js
+++ b/tests/legacy/fixtures/basic-with-custom-time-update-service/__expected/main.js
@@ -115,7 +115,7 @@
 	function update() {
 	  
 	    if (hasSW()) {
-	      navigator.serviceWorker.getRegistration().then((registration) => {
+	      navigator.serviceWorker.getRegistration().then(function(registration) {
 	        if (!registration) return;
 	        return registration.update();
 	      });

--- a/tests/legacy/fixtures/basic-with-default-update-service/__expected/main.js
+++ b/tests/legacy/fixtures/basic-with-default-update-service/__expected/main.js
@@ -115,7 +115,7 @@
 	function update() {
 	  
 	    if (hasSW()) {
-	      navigator.serviceWorker.getRegistration().then((registration) => {
+	      navigator.serviceWorker.getRegistration().then(function(registration) {
 	        if (!registration) return;
 	        return registration.update();
 	      });

--- a/tests/legacy/fixtures/basic-with-runtime/__expected/main.js
+++ b/tests/legacy/fixtures/basic-with-runtime/__expected/main.js
@@ -115,7 +115,7 @@
 	function update() {
 	  
 	    if (hasSW()) {
-	      navigator.serviceWorker.getRegistration().then((registration) => {
+	      navigator.serviceWorker.getRegistration().then(function(registration) {
 	        if (!registration) return;
 	        return registration.update();
 	      });

--- a/tests/legacy/fixtures/paths-explicit-absolute-tools-override-outside/__expected/appcache/manifest.appcache
+++ b/tests/legacy/fixtures/paths-explicit-absolute-tools-override-outside/__expected/appcache/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#ver:c79becd30557c1ea45f065b1cad68927d1be9b16
+#ver:098a6d48cfe88afd6528689e7959874c25563a12
 
 CACHE:
 /dist/main.js

--- a/tests/legacy/fixtures/paths-explicit-absolute-tools-override-outside/__expected/dist/main.js
+++ b/tests/legacy/fixtures/paths-explicit-absolute-tools-override-outside/__expected/dist/main.js
@@ -115,7 +115,7 @@
 	function update() {
 	  
 	    if (hasSW()) {
-	      navigator.serviceWorker.getRegistration().then((registration) => {
+	      navigator.serviceWorker.getRegistration().then(function(registration) {
 	        if (!registration) return;
 	        return registration.update();
 	      });

--- a/tests/legacy/fixtures/paths-explicit-absolute-tools-override-outside/__expected/sw.js
+++ b/tests/legacy/fixtures/paths-explicit-absolute-tools-override-outside/__expected/sw.js
@@ -15,11 +15,11 @@ var __wpo = {
     "/images/logo_grey.svg"
   ],
   "hashesMap": {
-    "8e1ecdfbbd7ad0785bcbcc56a691652acb71a4a0": "/dist/main.js"
+    "83a2bb7d9888ec4bfd9fc24351b96465cb775a44": "/dist/main.js"
   },
   "strategy": "changed",
   "responseStrategy": "cache-first",
-  "version": "c79becd30557c1ea45f065b1cad68927d1be9b16",
+  "version": "098a6d48cfe88afd6528689e7959874c25563a12",
   "name": "webpack-offline",
   "relativePaths": false
 };

--- a/tpls/runtime-template.js
+++ b/tpls/runtime-template.js
@@ -207,7 +207,7 @@ function applyUpdate(callback, errback) {
 function update() {
   <% if (typeof ServiceWorker !== 'undefined') { %>
     if (hasSW()) {
-      navigator.serviceWorker.getRegistration().then((registration) => {
+      navigator.serviceWorker.getRegistration().then(function(registration) {
         if (!registration) return;
         return registration.update();
       });


### PR DESCRIPTION
Using latest release of this plugin has thrown some error in some browser that doesn't support es6 syntax, need to change this line bro.