### PR TITLE
Typescript definitions for runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,18 @@ require('offline-plugin/runtime').install();
 
 ... and for Typescript users:
 ```ts
+// simple installation
 import * as Runtime from 'offline-plugin/runtime';
 Runtime.install();
+
+// use this when you want better tooling integration
+import { Runtime, InstallOptions } from 'offline-plugin';
+import * as runtime from 'offline-plugin/runtime';
+
+(runtime as Runtime).install({
+  onUpdateReady: () => runtime.applyUpdate(),
+	onUpdated: () => location.reload(),
+});
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Then, add the [runtime](docs/runtime.md) into your entry file (typically main en
 require('offline-plugin/runtime').install();
 ```
 
+... and for Typescript users:
+```ts
+import * as Runtime from 'offline-plugin/runtime';
+Runtime.install();
+```
+
 ## Docs
 
 * [Caches](docs/caches.md)

--- a/README.md
+++ b/README.md
@@ -51,21 +51,7 @@ Then, add the [runtime](docs/runtime.md) into your entry file (typically main en
 require('offline-plugin/runtime').install();
 ```
 
-... and for Typescript users:
-```ts
-// simple installation
-import * as Runtime from 'offline-plugin/runtime';
-Runtime.install();
-
-// use this when you want better tooling integration
-import { Runtime, InstallOptions } from 'offline-plugin';
-import * as runtime from 'offline-plugin/runtime';
-
-(runtime as Runtime).install({
-  onUpdateReady: () => runtime.applyUpdate(),
-	onUpdated: () => location.reload(),
-});
-```
+> You can find Typescript instructions [here](docs/typescript.md)
 
 ## Docs
 

--- a/configs/typescript.md
+++ b/configs/typescript.md
@@ -1,0 +1,21 @@
+To simply installing the runtime you can use following snippet:
+```ts
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
+OfflinePluginRuntime.install();
+```
+
+This example shows how to set the install options:
+```ts
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
+
+OfflinePluginRuntime.install({
+  onUpdateReady: () => OfflinePluginRuntime.applyUpdate(),
+  onUpdated: () => location.reload(),
+});
+```
+
+If you need to resolve the typescript definition file manually then
+you can add this line to your typescript file:
+```ts
+/// <reference path="node_modules/offline-plugin/offline-plugin.d.ts" />
+```

--- a/offline-plugin.d.ts
+++ b/offline-plugin.d.ts
@@ -1,5 +1,5 @@
-declare namespace OfflinePlugin {
-  interface InstallOptions {
+declare module 'offline-plugin/runtime' {
+  export interface InstallOptions {
     /**
      * Event called exactly once when ServiceWorker or AppCache is installed.
      * Can be useful to display "App is ready for offline usage" message.
@@ -45,41 +45,29 @@ declare namespace OfflinePlugin {
     onUpdated?: () => void;
   }
 
-  interface Runtime {
-    /**
-     * Starts installation flow for ServiceWorker/AppCache
-     * it's safe and must be called each time your page loads
-     * (i.e. do not wrap it into any conditions).
-     * 
-     * @param {InstallOptions} [options] The install options.
-     * 
-     * @memberOf RuntimeStatic
-     */
-    install(options?: InstallOptions): void;
+  /**
+   * Starts installation flow for ServiceWorker/AppCache
+   * it's safe and must be called each time your page loads
+   * (i.e. do not wrap it into any conditions).
+   * 
+   * @param {InstallOptions} [options] The install options.
+   * 
+   * @memberOf RuntimeStatic
+   */
+ export function install(options?: InstallOptions): void;
 
-    /**
-     * Used to apply update for existing installation.
-     * See InstallOptions.
-     * 
-     * @memberOf RuntimeStatic
-     */
-    applyUpdate(): void;
+  /**
+   * Used to apply update for existing installation.
+   * See InstallOptions.
+   * 
+   * @memberOf RuntimeStatic
+   */
+  export function applyUpdate(): void;
 
-    /**
-     * Performs check for updates of new ServiceWorker/AppCache.
-     * 
-     * @memberOf RuntimeStatic
-     */
-    update(): void;
-  }
-}
-
-declare var Runtime: OfflinePlugin.Runtime;
-
-declare module "offline-plugin" {
-  export = OfflinePlugin;
-}
-
-declare module "offline-plugin/runtime" {
-    export = Runtime;
+  /**
+   * Performs check for updates of new ServiceWorker/AppCache.
+   * 
+   * @memberOf RuntimeStatic
+   */
+  export function update(): void;
 }

--- a/offline-plugin.d.ts
+++ b/offline-plugin.d.ts
@@ -1,0 +1,84 @@
+declare namespace runtime {
+  interface InstallOptions {
+    /**
+     * Event called exactly once when ServiceWorker or AppCache is installed.
+     * Can be useful to display "App is ready for offline usage" message.
+     * 
+     * @memberOf InstallOptions
+     */
+    onInstalled?: () => void;
+
+    /**
+     * Not supported for AppCache.
+     * Event called when update is found and browsers started updating process.
+     * At this moment, some assets are downloading.
+     * 
+     * @memberOf InstallOptions
+     */
+    onUpdating?: () => void;
+
+    /**
+     * Event called when onUpdating phase finished.
+     * All required assets are downloaded at this moment and are ready to be updated.
+     * Call runtime.applyUpdate() to apply update.
+     * 
+     * @memberOf InstallOptions
+     */
+    onUpdateReady?: () => void;
+
+    /**
+     * Event called when upUpdating phase failed by some reason.
+     * Nothing is downloaded at this moment and current update process
+     * in your code should be canceled or ignored.
+     * 
+     * @memberOf InstallOptions
+     */
+    onUpdateFailed?: () => void;
+
+    /**
+     * Event called when update is applied,
+     * either by calling runtime.applyUpdate() or
+     * some other way by a browser itself.
+     * 
+     * @memberOf InstallOptions
+     */
+    onUpdated?: () => void;
+  }
+
+  interface Runtime {
+    /**
+     * Starts installation flow for ServiceWorker/AppCache
+     * it's safe and must be called each time your page loads
+     * (i.e. do not wrap it into any conditions).
+     * 
+     * @param {InstallOptions} [options] The install options.
+     * 
+     * @memberOf RuntimeStatic
+     */
+    install(options?: InstallOptions): void;
+
+    /**
+     * Used to apply update for existing installation.
+     * See InstallOptions.
+     * 
+     * @memberOf RuntimeStatic
+     */
+    applyUpdate(): void;
+
+    /**
+     * Performs check for updates of new ServiceWorker/AppCache.
+     * 
+     * @memberOf RuntimeStatic
+     */
+    update(): void;
+  }
+}
+
+declare var Runtime: runtime.Runtime;
+
+declare module "offline-plugin" {
+}
+
+declare module "offline-plugin/runtime" {
+    export = Runtime;
+}

--- a/offline-plugin.d.ts
+++ b/offline-plugin.d.ts
@@ -1,4 +1,4 @@
-declare namespace runtime {
+declare namespace OfflinePlugin {
   interface InstallOptions {
     /**
      * Event called exactly once when ServiceWorker or AppCache is installed.
@@ -74,9 +74,10 @@ declare namespace runtime {
   }
 }
 
-declare var Runtime: runtime.Runtime;
+declare var Runtime: OfflinePlugin.Runtime;
 
 declare module "offline-plugin" {
+  export = OfflinePlugin;
 }
 
 declare module "offline-plugin/runtime" {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "lib/",
     "tpls/",
     "runtime.js",
-    "empty-entry.js"
+    "empty-entry.js",
+    "offline-plugin.d.ts"
   ],
+  "typings": "./offline-plugin.d.ts",
   "scripts": {
     "test": "node tests/legacy/run && eslint -c configs/eslint.tests.json 'tests/**/**.js'",
     "build": "./node_modules/.bin/babel src/ -d lib/",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "empty-entry.js",
     "offline-plugin.d.ts"
   ],
-  "typings": "./offline-plugin.d.ts",
+  "types": "./offline-plugin.d.ts",
   "scripts": {
     "test": "node tests/legacy/run && eslint -c configs/eslint.tests.json 'tests/**/**.js'",
     "build": "./node_modules/.bin/babel src/ -d lib/",


### PR DESCRIPTION
I've successfully tested the offline-plugin typings with 'npm pack' in a local project.
Now you can use f.e. these lines of code with typescript:
```import * as Runtime from 'offline-plugin/runtime';

Runtime.install({
  onUpdateReady: () => Runtime.applyUpdate(),
	onUpdated: () => location.reload()
});```