### PR TITLE
[WIP] Attempt at making service worker autoUpdate faster

### DIFF
--- a/tpls/runtime-template.js
+++ b/tpls/runtime-template.js
@@ -49,6 +49,7 @@ function install(options) {
           sw.onstatechange = stateChangeHandler;
 
           function onUpdateStateChange() {
+            let waiting = false
             switch (sw.state) {
               case 'redundant': {
                 sendEvent('onUpdateFailed');
@@ -60,8 +61,13 @@ function install(options) {
                   sendEvent('onUpdating');
                 }
               } break;
-
+              case 'waiting': {
+                sw.skipWaiting();
+                waiting = true;
+              }
               case 'installed': {
+                if (waiting) window.location.reload()
+                
                 if (!ignoreWaiting) {
                   sendEvent('onUpdateReady');
                 }


### PR DESCRIPTION
I know this isn't complete, and there should be a new configuration option. After reading over this: https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/lifecycle#waiting 

I realized, even though auto update works and downloads a new service worker, it won't be used until all tabs are closed and reopened.

My idea is to add a config option, `forceRefreshOnUpdate` or something. When a new service worker is downloaded, it will be force updated, and once installed, it will reload the page. 

This way when pushing out new app releases, everyone will immediately be on it. Without doing a page refresh, you can run into problems with the old code fetching new files, which is why I want to do a page reload. This should be fast, since it is already cached by the new worker.

It would also be cool to add some sort of hook into this, so that in your app you can display a notice saying the app was just updated. 

Thoughts?