### PR TITLE
add support for regex in cache paths

### DIFF
--- a/docs/caches.md
+++ b/docs/caches.md
@@ -8,7 +8,7 @@ ___________________________________
 Tells to the plugin what to cache and how.
 
 * `'all'`: means that everything (all the webpack output assets) and URLs listed in `externals` option will be cached on install.
-* `Object`: Object with 3 possible sections (properties) of type `Array<string|RegExp>`: `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
+* `Object`: Object with 3 possible sections (properties) of type `Array<string | RegExp>`: `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
 
 > Default: `'all'`.
 

--- a/docs/caches.md
+++ b/docs/caches.md
@@ -8,7 +8,7 @@ ___________________________________
 Tells to the plugin what to cache and how.
 
 * `'all'`: means that everything (all the webpack output assets) and URLs listed in `externals` option will be cached on install.
-* `Object`: Object with 3 possible sections (properties) of type `Array<string>`: `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
+* `Object`: Object with 3 possible sections (properties) of type `Array<string|RegExp>`: `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
 
 > Default: `'all'`.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -8,7 +8,7 @@ _Also see list of default options [here](https://github.com/NekR/offline-plugin/
 Allows you to define what to cache and how.
 
 * `'all'`: means that everything (all the webpack output assets) and URLs listed in `externals` option will be cached on install.
-* `Object`: Object with 3 possible `Array<string>` sections (properties): `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
+* `Object`: Object with 3 possible `Array<string|RegExp>` sections (properties): `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
 
 [More details about `caches`](caches.md)
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -8,7 +8,7 @@ _Also see list of default options [here](https://github.com/NekR/offline-plugin/
 Allows you to define what to cache and how.
 
 * `'all'`: means that everything (all the webpack output assets) and URLs listed in `externals` option will be cached on install.
-* `Object`: Object with 3 possible `Array<string|RegExp>` sections (properties): `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
+* `Object`: Object with 3 possible `Array<string | RegExp>` sections (properties): `main`, `additional`, `optional`. All sections are optional and by default are empty (no assets added).
 
 [More details about `caches`](caches.md)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -392,7 +392,16 @@ var OfflinePlugin = (function () {
 
               var magic = undefined;
 
-              if (typeof cacheKey === 'string' && !(0, _miscUtils.isAbsoluteURL)(cacheKey) && cacheKey[0] !== '/' && cacheKey.indexOf('./') !== 0 && (magic = (0, _miscUtils.hasMagic)(cacheKey)) || typeof cacheKey !== 'string' && (magic = (0, _miscUtils.hasMagic)(cacheKey))) {
+              if (typeof cacheKey === 'string') {
+                magic = !(0, _miscUtils.isAbsoluteURL)(cacheKey) && cacheKey[0] !== '/' && cacheKey.indexOf('./') !== 0 && (0, _miscUtils.hasMagic)(cacheKey);
+              } else if (cacheKey instanceof RegExp) {
+                magic = (0, _miscUtils.hasMagic)(cacheKey);
+              } else {
+                // Ignore non-string and non-RegExp keys
+                return;
+              }
+
+              if (magic) {
                 var matched = undefined;
 
                 for (var i = 0, len = assets.length; i < len; i++) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -392,7 +392,7 @@ var OfflinePlugin = (function () {
 
               var magic = undefined;
 
-              if (!(0, _miscUtils.isAbsoluteURL)(cacheKey) && cacheKey[0] !== '/' && cacheKey.indexOf('./') !== 0 && (magic = (0, _miscUtils.hasMagic)(cacheKey))) {
+              if (typeof cacheKey === 'string' && !(0, _miscUtils.isAbsoluteURL)(cacheKey) && cacheKey[0] !== '/' && cacheKey.indexOf('./') !== 0 && (magic = (0, _miscUtils.hasMagic)(cacheKey)) || typeof cacheKey !== 'string' && (magic = (0, _miscUtils.hasMagic)(cacheKey))) {
                 var matched = undefined;
 
                 for (var i = 0, len = assets.length; i < len; i++) {

--- a/lib/misc/utils.js
+++ b/lib/misc/utils.js
@@ -22,6 +22,16 @@ var isAbsolutePath = _path2['default'].isAbsolute;
 // (glob.hasMagic)
 
 function hasMagic(pattern, options) {
+
+  //support RegExp as well as glob
+  if (pattern instanceof RegExp) {
+    return {
+      match: function match(str) {
+        return pattern.test(str);
+      }
+    };
+  }
+
   var minimatch = new _minimatch.Minimatch(pattern, options);
   var set = minimatch.set;
 

--- a/lib/misc/utils.js
+++ b/lib/misc/utils.js
@@ -22,8 +22,7 @@ var isAbsolutePath = _path2['default'].isAbsolute;
 // (glob.hasMagic)
 
 function hasMagic(pattern, options) {
-
-  //support RegExp as well as glob
+  //Support RegExp as well as glob
   if (pattern instanceof RegExp) {
     return {
       match: function match(str) {

--- a/src/index.js
+++ b/src/index.js
@@ -399,14 +399,14 @@ export default class OfflinePlugin {
           }
 
           let magic;
-
+          
           if (
-            typeof cacheKey === 'string' &&
+            (typeof cacheKey === 'string' &&
             !isAbsoluteURL(cacheKey) &&
             cacheKey[0] !== '/' &&
             cacheKey.indexOf('./') !== 0 &&
-            (magic = hasMagic(cacheKey)) ||
-            (magic = hasMagic(cacheKey))
+            (magic = hasMagic(cacheKey))) ||
+            (typeof cacheKey !== 'string' && (magic = hasMagic(cacheKey)))
           ) {
             let matched;
 

--- a/src/index.js
+++ b/src/index.js
@@ -399,15 +399,21 @@ export default class OfflinePlugin {
           }
 
           let magic;
-          
-          if (
-            (typeof cacheKey === 'string' &&
-            !isAbsoluteURL(cacheKey) &&
-            cacheKey[0] !== '/' &&
-            cacheKey.indexOf('./') !== 0 &&
-            (magic = hasMagic(cacheKey))) ||
-            (typeof cacheKey !== 'string' && (magic = hasMagic(cacheKey)))
-          ) {
+
+          if (typeof cacheKey === 'string') {
+            magic =
+              !isAbsoluteURL(cacheKey) &&
+              cacheKey[0] !== '/' &&
+              cacheKey.indexOf('./') !== 0 &&
+              hasMagic(cacheKey);
+          } else if (cacheKey instanceof RegExp) {
+            magic = hasMagic(cacheKey);
+          } else {
+            // Ignore non-string and non-RegExp keys
+            return;
+          }
+
+          if (magic) {
             let matched;
 
             for (let i = 0, len = assets.length; i < len; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -401,9 +401,11 @@ export default class OfflinePlugin {
           let magic;
 
           if (
+            typeof cacheKey === 'string' &&
             !isAbsoluteURL(cacheKey) &&
             cacheKey[0] !== '/' &&
             cacheKey.indexOf('./') !== 0 &&
+            (magic = hasMagic(cacheKey)) ||
             (magic = hasMagic(cacheKey))
           ) {
             let matched;

--- a/src/misc/utils.js
+++ b/src/misc/utils.js
@@ -6,8 +6,7 @@ const isAbsolutePath = path.isAbsolute;
 // Based on https://github.com/isaacs/node-glob/blob/master/glob.js#L83
 // (glob.hasMagic)
 export function hasMagic(pattern, options) {
-
-  //support RegExp as well as glob
+  //Support RegExp as well as glob
   if (pattern instanceof RegExp) {
     return {
       match: str => pattern.test(str)
@@ -27,7 +26,7 @@ export function hasMagic(pattern, options) {
     }
   }
 
-  return false
+  return false;
 }
 
 export function getSource(source) {

--- a/src/misc/utils.js
+++ b/src/misc/utils.js
@@ -6,6 +6,14 @@ const isAbsolutePath = path.isAbsolute;
 // Based on https://github.com/isaacs/node-glob/blob/master/glob.js#L83
 // (glob.hasMagic)
 export function hasMagic(pattern, options) {
+
+  //support RegExp as well as glob
+  if (pattern instanceof RegExp) {
+    return {
+      match: str => pattern.test(str)
+    };
+  }
+
   const minimatch = new Minimatch(pattern, options);
   const set = minimatch.set;
 

--- a/tests/legacy/fixtures/paths-regex/__expected/appcache/manifest.appcache
+++ b/tests/legacy/fixtures/paths-regex/__expected/appcache/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#ver:da39a3ee5e6b4b0d3255bfef95601890afd80709
+#ver:f2435b5e97ab165cde456b61eb28bf8bc103076e
 
 CACHE:
 ../main.js

--- a/tests/legacy/fixtures/paths-regex/__expected/appcache/manifest.appcache
+++ b/tests/legacy/fixtures/paths-regex/__expected/appcache/manifest.appcache
@@ -1,0 +1,8 @@
+CACHE MANIFEST
+#ver:da39a3ee5e6b4b0d3255bfef95601890afd80709
+
+CACHE:
+../main.js
+
+NETWORK:
+*

--- a/tests/legacy/fixtures/paths-regex/__expected/appcache/manifest.html
+++ b/tests/legacy/fixtures/paths-regex/__expected/appcache/manifest.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html manifest="manifest.appcache"></html>

--- a/tests/legacy/fixtures/paths-regex/__expected/main.js
+++ b/tests/legacy/fixtures/paths-regex/__expected/main.js
@@ -1,0 +1,50 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	
+
+/***/ }
+/******/ ]);

--- a/tests/legacy/fixtures/paths-regex/__expected/sw.js
+++ b/tests/legacy/fixtures/paths-regex/__expected/sw.js
@@ -1,0 +1,18 @@
+var __wpo = {
+  "assets": {
+    "main": [
+      "./main.js"
+    ],
+    "additional": [],
+    "optional": []
+  },
+  "externals": [],
+  "hashesMap": {
+    "fe8df8db17e5f8edb5c44ada1a7fdd9fe1a5012c": "./main.js"
+  },
+  "strategy": "changed",
+  "responseStrategy": "cache-first",
+  "version": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+  "name": "webpack-offline",
+  "relativePaths": true
+};

--- a/tests/legacy/fixtures/paths-regex/__expected/sw.js
+++ b/tests/legacy/fixtures/paths-regex/__expected/sw.js
@@ -12,7 +12,7 @@ var __wpo = {
   },
   "strategy": "changed",
   "responseStrategy": "cache-first",
-  "version": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+  "version": "f2435b5e97ab165cde456b61eb28bf8bc103076e",
   "name": "webpack-offline",
   "relativePaths": true
 };

--- a/tests/legacy/fixtures/paths-regex/webpack.config.js
+++ b/tests/legacy/fixtures/paths-regex/webpack.config.js
@@ -2,5 +2,5 @@ module.exports = __CONFIG__({
   caches: {
     main: [/\.js$/]
   },
-  version: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+  version: '[hash]'
 });

--- a/tests/legacy/fixtures/paths-regex/webpack.config.js
+++ b/tests/legacy/fixtures/paths-regex/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = __CONFIG__({
+  caches: {
+    main: [/\.js$/]
+  },
+  version: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+});


### PR DESCRIPTION
Hi,

My app has files named like this:
- `client.[hash].js` 
- `client.[id].[hash].js`

I want to include `client.[hash].js` in my `main` cache and `client.[id].[hash].js` in my `optional` cache. Using a glob makes this ~difficult~ (impossible?) because a glob like `client.*.js` always matches both files.

I want to be able to use a `RegExp` for the cache configuration options in order to get around this problem e.g. `/client.[^.]+.js/`
