### PR TITLE
AppCache fix for slow updates

### DIFF
--- a/tpls/appcache-frame.tpl
+++ b/tpls/appcache-frame.tpl
@@ -90,9 +90,6 @@
         clearInterval(downloadingInterval);
         downloadingInterval = null;
       }
-
-      applicationCache.removeEventListener('downloading', onDownloadingEvent);
-      applicationCache.removeEventListener('progress', onDownloadingEvent);
     }
 
     function cleanUp() {
@@ -102,10 +99,6 @@
       }
 
       downloadingCleanUp();
-
-      applicationCache.removeEventListener('updateready', onUpdateReadyEvent);
-      applicationCache.removeEventListener('cached', onInstalledEvent);
-      applicationCache.removeEventListener('obsolete', onObsoleteEvent);
 
       if (updateReadyInterval) {
         clearInterval(updateReadyInterval);


### PR DESCRIPTION
related to #241 and #210 

This patch simply prevents unregistering of the Application Cache event handlers after 5 seconds - only the timer is still being stopped after 5 seconds (the timer is used as a workaround should events not work).

This fixes `offline-plugin` for iPhone/iPad/Safari (tested) and IE/Edge (probably) when 5 seconds are not enough to check for updates and download assets.

IMHO this shouldn't break anything as the timer-workaround will behave like before. The 5-seconds problem will continue to exist for situations where the timer is really needed (when events don't work due to browser bugs).

I don't know which browsers really need the timer hack, but events seem to work fine on iOS/Webkit and also IE10 & Edge, where this patch makes a huge difference, because application get the chance to update immediately. 