### PR TITLE
Setup for more flexible responseStrategy

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -35,7 +35,8 @@ Response strategy. Whether to use a cache or network first for responses. Specif
 responseStrategy: [
   { patterns: /^\/server/, strategy: 'network-first' },
   { patterns: /./, strategy: 'cache-first' } // Matches everything else
-]```
+]
+```
 
 > Default: `'cache-first'`.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -22,8 +22,21 @@ Same as `webpack`'s `output.publicPath` option. Useful to specify or override `p
 `publicPath: '/project/'`  
 `publicPath: 'https://example.com/project'`  
 
-#### `responseStrategy: 'cache-first' | 'network-first'`
-Response strategy. Whether to use a cache or network first for responses.
+#### `responseStrategy: 'cache-first' | 'network-first' | Array<Object>`
+Response strategy. Whether to use a cache or network first for responses. Specify the object for regex support.
+
+* `'cache-first'`: Means that the cache will be checked first and will fall back to network when there is no cache.
+* `'network-first'`: Means that the network will be tried first and will fall back to cache if the network fails.
+* `Array<Object>`: Array of objects with these two required fields: `pattern` for a regular expression pattern for the url. `strategy` a strategy name with one of these values: `'cache-first' | 'network-first'`. This allows you to specify different strategies for different urls. The strategy of the first pattern that matched will be used. If nothing matched then the default will be used.
+
+> __Examples:__  
+`responseStrategy: 'network-first'`
+```
+responseStrategy: [
+  { patterns: /^\/server/, strategy: 'network-first' },
+  { patterns: /./, strategy: 'cache-first' } // Matches everything else
+]```
+
 > Default: `'cache-first'`.
 
 #### `updateStrategy: 'changed' | 'all'`

--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -325,9 +325,9 @@ function WebpackServiceWorker(params, helpers) {
 
     if (responseStrategy === 'network-first') {
       return networkFirstResponse;
-    } else {
-      return cacheFirstResponse;
     }
+
+    return cacheFirstResponse;
   }
 
   function cacheFirstResponse(event, urlString, cacheUrl) {

--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -323,7 +323,7 @@ function WebpackServiceWorker(params, helpers) {
 
     var strategy = _ref.strategy;
 
-    if (responseStrategy === 'network-first') {
+    if (strategy === 'network-first') {
       return networkFirstResponse;
     }
 

--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -282,17 +282,7 @@ function WebpackServiceWorker(params, helpers) {
     // Logic of caching / fetching is here
     // * urlString -- url to match from the CACHE_NAME
     // * event.request -- original Request to perform fetch() if necessary
-    var resource = undefined;
-
-    if (responseStrategy === 'network-first') {
-      resource = networkFirstResponse(event, urlString, cacheUrl);
-    }
-    // 'cache-first'
-    // (responseStrategy has been validated before)
-    else {
-        resource = cacheFirstResponse(event, urlString, cacheUrl);
-      }
-
+    var resource = resolveResponseStrategy(responseStrategy, urlString)(event, urlString, cacheUrl);
     if (navigateFallbackURL && isNavigateRequest(event.request)) {
       resource = handleNavigateFallback(resource);
     }
@@ -311,6 +301,34 @@ function WebpackServiceWorker(params, helpers) {
         }break;
     }
   });
+
+  function resolveResponseStrategy(responseStrategy, urlString) {
+    if (!Array.isArray(responseStrategy)) {
+      responseStrategy = [{
+        pattern: /./,
+        strategy: responseStrategy
+      }];
+    }
+
+    var _ref = responseStrategy.find(function (_ref2) {
+      var pattern = _ref2.pattern;
+      var strategy = _ref2.strategy;
+
+      if (!pattern instanceof RegExp) {
+        return false;
+      }
+
+      return pattern.test(urlString);
+    }) || { strategy: '' };
+
+    var strategy = _ref.strategy;
+
+    if (responseStrategy === 'network-first') {
+      return networkFirstResponse;
+    } else {
+      return cacheFirstResponse;
+    }
+  }
 
   function cacheFirstResponse(event, urlString, cacheUrl) {
     return cachesMatch(cacheUrl, CACHE_NAME).then(function (response) {

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -333,9 +333,8 @@ function WebpackServiceWorker(params, helpers) {
     if (responseStrategy === 'network-first') {
       return networkFirstResponse;
     }
-    else {
-      return cacheFirstResponse;
-    }
+    
+    return cacheFirstResponse;
   }
 
   function cacheFirstResponse(event, urlString, cacheUrl) {

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -330,7 +330,7 @@ function WebpackServiceWorker(params, helpers) {
       return pattern.test(urlString);
     }) || { strategy: '' };
 
-    if (responseStrategy === 'network-first') {
+    if (strategy === 'network-first') {
       return networkFirstResponse;
     }
     


### PR DESCRIPTION
This PR is not finished and is open for the discussion.

This PR should make it possible to have different response strategies for different requests.
The property responseStrategy can now also be filled in with an object.

Example:
```javascript
responseStrategy: [
  { pattern: /^\/server/, strategy: 'network-first' },
  { pattern: /./, strategy: 'cache-first' } // Matches everything else
]
```
What it will do is: It will check the requested url against all the responseStrategies (from top down) and if it find a match for the pattern and the url. Then that strategy will be used.
If nothing matches then the default ('cache-first') will be used.

It now matches against urlString but i am not sure if i should use urlString or cacheUrl

You can still use the already existing options so `responseStrategy: 'network-first'` should still work.

Todo:
- [ ] Fix tests
- [ ] Add tests

Issue: #275 