### PR TITLE
Fixes thrown exceptions in apps using postMessage

### DIFF
--- a/tpls/runtime-template.js
+++ b/tpls/runtime-template.js
@@ -144,6 +144,7 @@ function install(options) {
             if (e.source !== iframe.contentWindow) return;
 
             var match = (e.data + '').match(/__offline-plugin_AppCacheEvent:(\w+)/);
+            if (!match) return;
             var event = match[1];
 
             if (typeof options[event] === 'function') {


### PR DESCRIPTION
My app uses postMessage for it's own purposes. This fixes an error that occurs when the appcache updates choke on messages from the application.