### PR TITLE
Update update-strategies.md

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,3 +24,11 @@ This is because the [opaque request](http://stackoverflow.com/questions/36292537
 
 **Why isn't my SPA working in offline mode?**  
 There is probably something wrong with your configuration. See the [SPA example](examples/SPA.md)
+
+**How can I notify users that a new version of my webpage is available?**  
+In the `offline-plugin/runtime`'s `install` method, you can pass a config object with event hooks, one of which is the `onUpdateReady`, that fires when all required assets are downloaded and ready to be updated. In this callback, you can either call `runtime.applyUpdate()` to apply updates directly, or in some way prompt for user input, and then apply them. See [`install-options`](runtime.md#install-options) and the [offline-plugin.pwa example](https://github.com/NekR/offline-plugin-pwa/blob/master/src/main.js)
+```js
+onUpdateReady: function() {
+  OfflinePlugin.applyUpdate();
+}
+ ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,3 +13,4 @@
 * **ServiceWorker is wrongly caching api requests.** There are multiple ways to fix this depending on your setup. One way is to set [cacheMaps.requestTypes](cache-maps.md) to `['navigate']`, caching only those requests.
 * **AppCache events are not worknig properly.** `AppCache.events` are known to be a bit buggy (see [updates](updates.md)). Try to avoid using them if possible.
 * **Resources served from a CDN are not being cached** `offline-plugin` can cache resources served from a CDN, given the correct configuration. Make sure the resources are served with the correct headers.
+* **The serviceworker is preventing redirections from taking place.** If `navigateFallbackURL` is set, it treats redirects as fails. Either set `ServiceWorker.navigateFallbackForRedirects` to `false`, or (preferred) use `cacheMaps` and remove `navigateFallbackURL`.

--- a/docs/update-strategies.md
+++ b/docs/update-strategies.md
@@ -2,6 +2,6 @@
 
 * **`all`** strategy uses `version` passed to [`options`](options.md) as a cache tag. When version changes, old version cache is removed and new files are downloaded. Of course if files with the same name were not changed (HTTP status 304), the browser probably won't download them again and will just update cache.
 * **`changed`** strategy is more advanced than `all`. `offline-plugin` will calculate the files' hashes on it's own, independant of `webpack`s hash calculation. Even if a file is renamed, if the hash is the same, it will not be downloaded again, but rather just renamed. **With this strategy enabled, `index.html` (or other files without dynamic name) should be placed in `main` section of the cache, otherwise they won't be revalidated**.
-  * For `ServiceWorker` this means that only new files will be downloaded and missing files deleted from the cache.
+  * For `ServiceWorker` this means that only new/changed files will be downloaded and missing files deleted from the cache.
   * `AppCache` does not support the `changed` strategy and will always use the `all` strategy.
 * `updateStrategy` does not apply to `externals`, as they're always revalidated/redownloaded on `ServiceWorker` update.

--- a/docs/update-strategies.md
+++ b/docs/update-strategies.md
@@ -1,7 +1,7 @@
 ## This doc is still under development
 
-* **`all`** strategy uses `version` passed to `options` as a cache tag. When version changes, old version cache is removed and new files are downloaded. Of course if files with the same name were not changed (HTTP status 304), the browser probably won't download them again and will just update cache.
-* **`changed`** strategy is more advanced than `all` or `hash`. `offline-plugin` will calculate the files' hashes on it's own, independant of `webpack`. Even if a file is renamed, if the hash is the same, the file isn't redownloaded, but rather just renamed. **With this strategy enabled, `index.html` (or other files without dynamic name) should be placed in `main` section of the cache, otherwise they won't be revalidated**.
+* **`all`** strategy uses `version` passed to [`options`](options.md) as a cache tag. When version changes, old version cache is removed and new files are downloaded. Of course if files with the same name were not changed (HTTP status 304), the browser probably won't download them again and will just update cache.
+* **`changed`** strategy is more advanced than `all`. `offline-plugin` will calculate the files' hashes on it's own, independant of `webpack`s hash calculation. Even if a file is renamed, if the hash is the same, it will not be downloaded again, but rather just renamed. **With this strategy enabled, `index.html` (or other files without dynamic name) should be placed in `main` section of the cache, otherwise they won't be revalidated**.
   * For `ServiceWorker` this means that only new files will be downloaded and missing files deleted from the cache.
-  * For `AppCache` it's basically the same as previous strategies since `AppCache` revalidates all the assets. (HTTP status 304 rule still applies).
-* `updateStrategy` does not apply to externals, as they're always revalidated/redownloaded on SW update.
+  * `AppCache` does not support the `changed` strategy and will always use the `all` strategy.
+* `updateStrategy` does not apply to `externals`, as they're always revalidated/redownloaded on `ServiceWorker` update.

--- a/docs/update-strategies.md
+++ b/docs/update-strategies.md
@@ -1,6 +1,7 @@
 ## This doc is still under development
 
-* `all` strategy uses `version` passed to options as a cache tag. When version changes, old version cache is removed and new files are downloaded. Of course if files has same name were not changed (304 status returned), then probably browser won't download them again and will just update cache.
-* `changed` strategy is more advanced than `all` or `hash`. To work properly it requires output assets to have unique names between compilations, e.g. _file's unique hash_ in its name. **With this strategy enabled, `index.html` file (or other files without dynamic name) should be placed in `main` section of the cache, otherwise they won't be revalidated**.
+* **`all`** strategy uses `version` passed to `options` as a cache tag. When version changes, old version cache is removed and new files are downloaded. Of course if files with the same name were not changed (HTTP status 304), the browser probably won't download them again and will just update cache.
+* **`changed`** strategy is more advanced than `all` or `hash`. `offline-plugin` will calculate the files' hashes on it's own, independant of `webpack`. Even if a file is renamed, if the hash is the same, the file isn't redownloaded, but rather just renamed. **With this strategy enabled, `index.html` (or other files without dynamic name) should be placed in `main` section of the cache, otherwise they won't be revalidated**.
   * For `ServiceWorker` this means that only new files will be downloaded and missing files deleted from the cache.
-  * For `AppCache` it's basically same as previous strategies since `AppCache` revalidates all the assets. 304 HTTP status rule of course still works.
+  * For `AppCache` it's basically the same as previous strategies since `AppCache` revalidates all the assets. (HTTP status 304 rule still applies).
+* `updateStrategy` does not apply to externals, as they're always revalidated/redownloaded on SW update.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offline-plugin",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "offline-plugin for webpack",
   "main": "lib/index.js",
   "files": [

--- a/tpls/runtime-template.js
+++ b/tpls/runtime-template.js
@@ -144,6 +144,7 @@ function install(options) {
             if (e.source !== iframe.contentWindow) return;
 
             var match = (e.data + '').match(/__offline-plugin_AppCacheEvent:(\w+)/);
+            if (!match) return;
             var event = match[1];
 
             if (typeof options[event] === 'function') {


### PR DESCRIPTION
fixes #295 in response to #292

A bit unsure if this still applies @NekR or it should be removed

> With this strategy enabled, index.html (or other files without dynamic name) should be placed in main section of the cache, otherwise they won't be revalidated.
> * For ServiceWorker this means that only new files will be downloaded and missing files deleted from the cache.
> * For AppCache it's basically the same as previous strategies since AppCache revalidates all the assets. (HTTP status 304 rule still applies).