### PR TITLE
Return registration from runtime.install()

### DIFF
--- a/tpls/runtime-template.js
+++ b/tpls/runtime-template.js
@@ -105,7 +105,7 @@ function install(options) {
           }
         };
 
-        registration.then(function(reg) {
+        return registration.then(function(reg) {
           // WTF no reg?
           if (!reg) return;
 
@@ -120,13 +120,12 @@ function install(options) {
           reg.onupdatefound = function() {
             handleUpdating(reg);
           };
+          return reg;
         }).catch(function(err) {
           sendEvent('onError');
           return Promise.reject(err);
         });
       <% } %>
-
-      return;
     }
   <% } %>
 


### PR DESCRIPTION
This is necessary so that one can subscribe users to web push notifications.

Let's assume I have a ServiceWorker at `push-sw.js` which listens to the `push` event:

```JS
// push-sw.js
self.addEventListener('push', (event) => {
  const data = event.data.json();
  // ...tons more code...
  return self.registration.showNotification(data.title, data.options);
})
```

I set up OfflinePlugin to include it like so:

```JS
new OfflinePlugin({
  ServiceWorker: {
    entry: 'push-sw.js'
  }
})
```

The issue is that I need to get the current ServiceWorker registration in order to get the Pushmanager, which I need to subscribe users to push notifications:

```JS
// HOW DO I GET serviceWorkerRegistration WHEN USING OFFLINE PLUGIN?!
var PushManager = serviceWorkerRegistration.pushManager;
```

So, this tiny patch returns the serviceworker registration from the `runtime.install` method so that we can do this:

```JS
runtime.install().then(registration => {
  if ('PushManager' in window) {
    // Get the Push Manager from the SW registration
    PushManager = registration.pushManager;
  }
});

// Now I can subscribe users to web push notifications! :tada:
PushManager.subscribe({
  userVisibleOnly: true,
  applicationServerKey: urlB64ToUint8Array('some-key')
})
```