### PR TITLE
Use webpack hooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,29 +214,28 @@ var OfflinePlugin = (function () {
         _this2.resolveToolPaths(tool, key, compiler);
       });
 
-      compiler.plugin('normal-module-factory', function (nmf) {
-        nmf.plugin('after-resolve', function (result, callback) {
-          var resource = _path3['default'].resolve(compiler.context, result.resource);
+      var afterResolveFn = function afterResolveFn(result, callback) {
+        var resource = _path3['default'].resolve(compiler.context, result.resource);
 
-          if (resource !== runtimePath) {
-            return callback(null, result);
-          }
-
-          var data = {
-            autoUpdate: _this2.autoUpdate
-          };
-
-          _this2.useTools(function (tool, key) {
-            data[key] = tool.getConfig(_this2);
-          });
-
-          result.loaders.push(_path3['default'].join(__dirname, 'misc/runtime-loader.js') + '?' + JSON.stringify(data));
-
+        if (resource !== runtimePath) {
           callback(null, result);
-        });
-      });
+          return;
+        }
 
-      compiler.plugin('make', function (compilation, callback) {
+        var data = {
+          autoUpdate: _this2.autoUpdate
+        };
+
+        _this2.useTools(function (tool, key) {
+          data[key] = tool.getConfig(_this2);
+        });
+
+        result.loaders.push(_path3['default'].join(__dirname, 'misc/runtime-loader.js') + '?' + JSON.stringify(data));
+
+        callback(null, result);
+      };
+
+      var makeFn = function makeFn(compilation, callback) {
         if (_this2.warnings.length) {
           [].push.apply(compilation.warnings, _this2.warnings);
         }
@@ -252,9 +251,9 @@ var OfflinePlugin = (function () {
         })['catch'](function (e) {
           throw e || new Error('Something went wrong');
         });
-      });
+      };
 
-      compiler.plugin('emit', function (compilation, callback) {
+      var emitFn = function emitFn(compilation, callback) {
         var runtimeTemplatePath = _path3['default'].resolve(__dirname, '../tpls/runtime-template.js');
         var hasRuntime = true;
 
@@ -295,7 +294,27 @@ var OfflinePlugin = (function () {
         }, function () {
           callback(new Error('Something went wrong'));
         });
-      });
+      };
+
+      if (compiler.hooks) {
+        (function () {
+          var plugin = { name: 'OfflinePlugin' };
+
+          compiler.hooks.normalModuleFactory.tap(plugin, function (nmf) {
+            nmf.hooks.afterResolve.tapAsync(plugin, afterResolveFn);
+          });
+
+          compiler.hooks.make.tapAsync(plugin, makeFn);
+          compiler.hooks.emit.tapAsync(plugin, emitFn);
+        })();
+      } else {
+        compiler.plugin('normal-module-factory', function (nmf) {
+          nmf.plugin('after-resolve', afterResolveFn);
+        });
+
+        compiler.plugin('make', makeFn);
+        compiler.plugin('emit', emitFn);
+      }
     }
   }, {
     key: 'setAssets',

--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -87,7 +87,7 @@ var ServiceWorker = (function () {
       var entry = loader + '!' + this.entry;
 
       childCompiler.context = compiler.context;
-      childCompiler.apply(new _webpackLibSingleEntryPlugin2['default'](compiler.context, entry, name));
+      new _webpackLibSingleEntryPlugin2['default'](compiler.context, entry, name).apply(childCompiler);
 
       if (this.minify === true) {
         if (!_miscGetUglifyPlugin2['default']) {
@@ -110,7 +110,7 @@ var ServiceWorker = (function () {
           }
         };
 
-        childCompiler.apply(new _miscGetUglifyPlugin2['default'](options));
+        new _miscGetUglifyPlugin2['default'](options).apply(childCompiler);
       } else if (this.minify !== false && _miscGetUglifyPlugin2['default']) {
         // Do not perform auto-minification if UglifyJsPlugin isn't installed
 
@@ -119,7 +119,7 @@ var ServiceWorker = (function () {
             var options = (0, _deepExtend2['default'])({}, plugin.options);
 
             options.test = new RegExp(name);
-            childCompiler.apply(new _miscGetUglifyPlugin2['default'](options));
+            new _miscGetUglifyPlugin2['default'](options).apply(childCompiler);
 
             return true;
           }
@@ -128,7 +128,7 @@ var ServiceWorker = (function () {
 
       // Needed for HMR. offline-plugin doesn't support it,
       // but added just in case to prevent other errors
-      childCompiler.plugin('compilation', function (compilation) {
+      var compilationFn = function compilationFn(compilation) {
         if (compilation.cache) {
           if (!compilation.cache[name]) {
             compilation.cache[name] = {};
@@ -136,7 +136,14 @@ var ServiceWorker = (function () {
 
           compilation.cache = compilation.cache[name];
         }
-      });
+      };
+
+      if (childCompiler.hooks) {
+        var _plugin = { name: 'OfflinePlugin' };
+        childCompiler.hooks.compilation.tap(_plugin, compilationFn);
+      } else {
+        childCompiler.plugin('compilation', compilationFn);
+      }
 
       return new Promise(function (resolve, reject) {
         childCompiler.runAsChild(function (err, entries, childCompilation) {


### PR DESCRIPTION
In webpack 4, `Tapable#apply` and `Tapable#plugin` raise a **deprecation notice**.

- `Tapable#apply(plugin)` must be replaced by a call to `plugin.apply`
- `Tapable#plugin(hook, fn)` must be replaced by a call to `hook.tap` (or `hook.tapAsync`)

**Note:** This is breaking change because it drops webpack < 4 compatibility.