### PR TITLE
Doc update: clarify implications of default version config option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -69,7 +69,9 @@ Version of the cache. Can be a function, which is useful in _watch-mode_ when yo
 * `Function` is called with the plugin instance as the first argument
 * `string` which can be interpolated with `[hash]` token
 
-> Default: _Current date_
+> Default: _Current date_  
+> **Example:** `2018-6-20 09:53:56`  
+> Please note that if you use the default value (date and time), the version of service worker will change on each build of your project.
 
 #### `rewrites: Function | Object`
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -69,7 +69,7 @@ Version of the cache. Can be a function, which is useful in _watch-mode_ when yo
 * `Function` is called with the plugin instance as the first argument
 * `string` which can be interpolated with `[hash]` token
 
-> Default: _Current date_  
+> Default: _Current date and time_  
 > **Example:** `2018-6-20 09:53:56`  
 > Please note that if you use the default value (date and time), the version of service worker will change on each build of your project.
 


### PR DESCRIPTION
The version string is not just date but combination of date and **time**

In one of my projects we were running multiple replicas of frontend app and **each** replica on start up was running building the project before serving the app. Although the code is same which is being built is same in each of those replicas but the output of build is not same because builds did not complete at the same time and hence this version field was not same in the replicas.

Whenever the user's request is served from a different replica, the service worker will update itself.

This PR does not solve this problem but it communicates it in the documentation.