### PR TITLE
Fix cache key

### DIFF
--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -608,7 +608,7 @@ function WebpackServiceWorker(params, helpers) {
         var addAll = responses.map(function (_ref, i) {
           var response = _ref.response;
 
-          return cache.put(requests[i], response);
+          return cache.put(response.url, response);
         });
 
         return Promise.all(addAll);

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -624,7 +624,7 @@ function WebpackServiceWorker(params, helpers) {
 
       return deleting.then(() => {
         let addAll = responses.map(({ response }, i) => {
-          return cache.put(requests[i], response);
+          return cache.put(response.url, response);
         });
 
         return Promise.all(addAll);


### PR DESCRIPTION
Recently we received some reports that SW caches the wrong file (https://github.com/ant-design/ant-design/issues/11080). After some investigations, I found that if a URL request failed, then the failed request will be cached by another response. The reason is that when a request failed, the responses will be filtered in https://github.com/NekR/offline-plugin/blob/4553b5f5a6a02626b1985db2eb03f1f3622b859a/src/misc/sw-template.js#L622, but the requests are not filtered, so that `responses` get a different `length` than the reuqets which resulting in this line https://github.com/NekR/offline-plugin/blob/4553b5f5a6a02626b1985db2eb03f1f3622b859a/src/misc/sw-template.js#L627 get a wrong request for respone.