### PR TITLE
prevent setAssets from modifying original externals array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -327,7 +327,7 @@ var OfflinePlugin = (function () {
 
       var excludes = this.options.excludes;
       var assets = Object.keys(compilation.assets);
-      var externals = this.options.externals;
+      var externals = this.options.externals.slice();
 
       if (Array.isArray(excludes) && excludes.length) {
         assets = assets.filter(function (asset) {

--- a/src/index.js
+++ b/src/index.js
@@ -339,7 +339,7 @@ export default class OfflinePlugin {
 
     const excludes = this.options.excludes;
     let assets = Object.keys(compilation.assets);
-    let externals = this.options.externals;
+    let externals = this.options.externals.slice();
 
     if (Array.isArray(excludes) && excludes.length) {
       assets = assets.filter((asset) => {


### PR DESCRIPTION
When using this plugin with wds and hot reloading, we noticed that as we reloaded, we'd receive an increasing number of warnings from the plugin with every reload. There'd be no warnings at first, then the first reload, there'd be one warning about how we should put a resource into externals, then a second reload there'd be warnings about all of our external resources.

I tracked it down to `setAssets`, which is being modified as it checks the externals to ensure they're defined. However, that means that multiple entries into this function destroy the original array, and produce these warnings. During the initial build, we'd have our array full; first reload, we'd have it slightly empty; second reload and forward, the externals array would be empty.

The change here seems like the simplest fix to the problem, and I don't believe should introduce any unexpected issues. I've confirmed that it does resolve the problem on our end.