### PR TITLE
Respect __webpack_public_path__ (dynamic public paths)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -626,9 +626,9 @@ var OfflinePlugin = (function () {
       }
 
       if (this.relativePaths) {
-        tool.location = tool.output;
+        tool.location = '__webpack_public_path__ + ' + JSON.stringify(tool.output);
       } else if (this.publicPath && tool.publicPath) {
-        tool.location = tool.publicPath;
+        tool.location = JSON.stringify(tool.publicPath);
       } else if (this.publicPath) {
         var publicUrl = _url2['default'].parse(this.publicPath);
         var publicPath = publicUrl.pathname;
@@ -640,7 +640,7 @@ var OfflinePlugin = (function () {
           new Error('OfflinePlugin: Wrong ' + key + '.output value. Final ' + key + '.location URL path bounds are outside of publicPath');
         }
 
-        tool.location = _url2['default'].format(publicUrl);
+        tool.location = JSON.stringify(_url2['default'].format(publicUrl));
       }
 
       if (this.relativePaths) {

--- a/src/index.js
+++ b/src/index.js
@@ -649,9 +649,9 @@ export default class OfflinePlugin {
     }
 
     if (this.relativePaths) {
-      tool.location = tool.output;
+      tool.location = `__webpack_public_path__ + ${JSON.stringify(tool.output)}`;
     } else if (this.publicPath && tool.publicPath) {
-      tool.location = tool.publicPath;
+      tool.location = JSON.stringify(tool.publicPath);
     } else if (this.publicPath) {
       const publicUrl = url.parse(this.publicPath);
       const publicPath = publicUrl.pathname;
@@ -663,7 +663,7 @@ export default class OfflinePlugin {
         new Error(`OfflinePlugin: Wrong ${ key }.output value. Final ${ key }.location URL path bounds are outside of publicPath`);
       }
 
-      tool.location = url.format(publicUrl);
+      tool.location = JSON.stringify(url.format(publicUrl));
     }
 
     if (this.relativePaths) {

--- a/tests/browser/relative-paths-dynamic-public-path/server.js
+++ b/tests/browser/relative-paths-dynamic-public-path/server.js
@@ -1,0 +1,78 @@
+var path = require('path');
+
+var express = require('express');
+var app = express();
+
+var WWW_FOLDER = path.join(__dirname, 'www');
+
+app.get('/', serveIndex);
+
+app.get('/dist/sw.js', serveServiceWorker);
+app.use(express.static(WWW_FOLDER));
+
+app.get('/*', serveNotFound);
+
+let indexPreload = 0;
+let notFoundPreload = 0;
+
+function serveServiceWorker(req, res) {
+  res.sendFile(path.join(WWW_FOLDER, 'dist/sw.js'), {
+    cacheControl: false,
+    acceptRanges: false,
+    headers: {
+      'Cache-Control': 'no-cache',
+      'Service-Worker-Allowed': '/'
+    }
+  });
+}
+
+function serveIndex(req, res) {
+  if (req.headers['service-worker-navigation-preload']) {
+    res.send(`
+      <!doctype html>
+      <body>
+        <div id="page">preload index</div>
+        <script src="/dist/main.js"></script>
+      </body>
+    `);
+
+    return;
+  }
+
+  res.sendFile(path.join(WWW_FOLDER, 'index.html'), {
+    cacheControl: false,
+    acceptRanges: false,
+    headers: {
+      'Cache-Control': 'no-cache'
+    }
+  });
+}
+
+function serveNotFound(req, res) {
+  if (req.url === '/not-found' && req.headers['service-worker-navigation-preload']) {
+    res.send(`
+      <!doctype html>
+      <body>
+        <div id="page">preload not-found</div>
+        <script src="/dist/main.js"></script>
+      </body>
+    `);
+
+    return;
+  }
+
+  res.end();
+}
+
+// Not used
+function serveAppShell(req, res) {
+  res.sendFile(path.join(WWW_FOLDER, 'app-shell.html'), {
+    cacheControl: false,
+    acceptRanges: false,
+    headers: {
+      'Cache-Control': 'no-cache'
+    }
+  });
+}
+
+module.exports = __createServer(app);

--- a/tests/browser/relative-paths-dynamic-public-path/src/index.html
+++ b/tests/browser/relative-paths-dynamic-public-path/src/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<body>
+  <div id="page">index</div>
+  <script src="/dist/main.js"></script>
+</body>

--- a/tests/browser/relative-paths-dynamic-public-path/src/main.js
+++ b/tests/browser/relative-paths-dynamic-public-path/src/main.js
@@ -1,0 +1,5 @@
+const OfflinePlugin = require(process.env.OFFLINE_PLUGIN_ROOT + '/runtime');
+
+__webpack_public_path__ = '/dist/';
+
+OfflinePlugin.install();

--- a/tests/browser/relative-paths-dynamic-public-path/test.js
+++ b/tests/browser/relative-paths-dynamic-public-path/test.js
@@ -1,0 +1,38 @@
+const puppeteer = require("puppeteer");
+
+const server = require("./server");
+const webpack = __buildWebpack("webpack.config.js");
+
+module.exports = new Promise(resolve => {
+  after(async () => {
+    (await server).close();
+    resolve();
+  });
+});
+
+describe("testing dynamic public paths", function() {
+  let browser;
+  let page;
+
+  before(async () => {
+    await server;
+    await webpack;
+
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"]
+    });
+    page = await browser.newPage();
+  });
+
+  after(async () => {
+    // await browser.close();
+  });
+
+  it("should use __webpack_public_path__ to load sw.js", async function() {
+    await page.goto(`${__SERVER__}/`);
+    await page.evaluate(function() {
+      return navigator.serviceWorker.ready;
+    });
+  });
+});

--- a/tests/browser/relative-paths-dynamic-public-path/webpack.config.js
+++ b/tests/browser/relative-paths-dynamic-public-path/webpack.config.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const { join } = path;
+
+const OfflinePlugin = require(process.env.OFFLINE_PLUGIN_ROOT);
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const DefinePlugin = require('webpack/lib/DefinePlugin');
+
+const webpackMajorVersion = require('webpack/package.json').version.split('.')[0];
+
+const config = {
+  entry: {
+    main: join(__dirname, 'src/main.js'),
+  },
+
+  output: {
+    path: join(__dirname, 'www/dist'),
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+    publicPath: '/'
+  },
+
+  plugins: [
+    new CopyWebpackPlugin([
+      { from: join(__dirname, 'src/index.html'), to: join(__dirname, 'www' ) }
+    ]),
+    new DefinePlugin({
+      'process.env.OFFLINE_PLUGIN_ROOT': JSON.stringify(process.env.OFFLINE_PLUGIN_ROOT)
+    }),
+    new OfflinePlugin({
+      relativePaths: true,
+      ServiceWorker: {
+        scope: '/'
+      }
+    })
+  ]
+};
+
+if (webpackMajorVersion === '4') {
+  config.mode = 'none';
+}
+
+module.exports = config;

--- a/tpls/runtime-template.js
+++ b/tpls/runtime-template.js
@@ -20,7 +20,7 @@ function install(options) {
     if (hasSW()) {
       var registration = navigator.serviceWorker
         .register(
-          <%- JSON.stringify(ServiceWorker.location) %>, {
+          <%- ServiceWorker.location %>, {
             <% if (ServiceWorker.scope) { %>
               scope: <%- JSON.stringify(ServiceWorker.scope) %>,
             <% } %>


### PR DESCRIPTION
A much simpler solution for #151, #184 (#418).

When using relative paths, this ensures `sw.js` itself is loaded correctly.

---

To use a dynamic/runtime public path, set webpack's `__webpack_public_path__` global and set `relativePaths: true` in the offline-plugin config.